### PR TITLE
More protection against breaking the demo

### DIFF
--- a/Controllers/authController.php
+++ b/Controllers/authController.php
@@ -1,0 +1,13 @@
+<?php
+
+class FreshExtension_auth_Controller extends FreshRSS_auth_Controller {
+	public function indexAction(): void {
+	    $auth_type = Minz_Request::paramString('auth_type') ?: 'form';
+	    if (Minz_Request::isPost() && $auth_type !== 'form') {
+	        Minz_Request::bad('You can’t change the authentication method', ['c' => 'auth']);
+	        return;
+	    }
+
+	    parent::indexAction();
+	}
+}

--- a/Controllers/userController.php
+++ b/Controllers/userController.php
@@ -11,15 +11,56 @@ class FreshExtension_user_Controller extends FreshRSS_user_Controller {
 		}
 	}
 
-	public function manageAction(): void {
+	private static function notAllowed(): bool {
 		$username = Minz_Request::param('username');
 		if ($username === 'demo' && Minz_Request::isPost()) {
 			$url_redirect = array('c' => 'user', 'a' => 'details', 'params' => [
 				'username' => $username,
 			]);
 			Minz_Request::bad('You can’t change the demo user.', $url_redirect);
-		} else {
-			parent::manageAction();
+			return true;
 		}
+		return false;
 	}
+
+	public function manageAction(): void {
+		if (self::notAllowed()) return;
+		parent::manageAction();
+	}
+
+	/*
+	 * Block other functions called by manageAction()
+	 * See: https://github.com/FreshRSS/FreshRSS/blob/ce22997dfbe4a8f2a6efa6f77d5b0bfc7b2dabd1/app/Controllers/userController.php#L189-L211
+	 */
+
+	public function deleteAction(): void {
+		if (self::notAllowed()) return;
+		parent::deleteAction();
+	}
+	public function updateAction(): void {
+		if (self::notAllowed()) return;
+		parent::updateAction();
+	}
+	public function purgeAction(): void {
+		if (self::notAllowed()) return;
+		parent::purgeAction();
+	}
+	public function promoteAction(): void {
+		if (self::notAllowed()) return;
+		parent::promoteAction();
+	}
+	public function demoteAction(): void {
+		if (self::notAllowed()) return;
+		parent::demoteAction();
+	}
+	public function enableAction(): void {
+		if (self::notAllowed()) return;
+		parent::enableAction();
+	}
+	public function disableAction(): void {
+		if (self::notAllowed()) return;
+		parent::disableAction();
+	}
+
+	/* end */
 }

--- a/extension.php
+++ b/extension.php
@@ -37,6 +37,7 @@ class DemoExtension extends Minz_Extension {
     public function init() {
         $this->registerController('extension');
         $this->registerController('user');
+        $this->registerController('auth');
         $this->registerViews();
     }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Demo",
   "author": "Marien Fressinaud",
   "description": "Extension for the demo version of FreshRSS",
-  "version": 0.1,
+  "version": 0.2,
   "entrypoint": "Demo",
   "type": "system"
 }


### PR DESCRIPTION
Disallow changing the authentication method in `authController` so that this doesn't happen:

![image](https://github.com/user-attachments/assets/65fa36da-f620-4955-b99a-5a8e1476f2f5)

I took the screenshot yesterday, and today it's still broken: https://demo.freshrss.org
And I also realized that the `demo` user can be modified by calling [other actions](https://github.com/FreshRSS/FreshRSS/blob/ce22997dfbe4a8f2a6efa6f77d5b0bfc7b2dabd1/app/Controllers/userController.php#L189-L211) instead, so that's now fixed in `userController`.