### PR TITLE
Disallow changing some settings (lazyload + unsafe login)

### DIFF
--- a/Controllers/authController.php
+++ b/Controllers/authController.php
@@ -7,6 +7,7 @@ class FreshExtension_auth_Controller extends FreshRSS_auth_Controller {
 	        Minz_Request::bad('You can’t change the authentication method', ['c' => 'auth']);
 	        return;
 	    }
+	    Minz_Request::_param('unsafe_autologin', false); // Disallow enabling unsafe autologin, since it may cause issues
 
 	    parent::indexAction();
 	}

--- a/Controllers/configureController.php
+++ b/Controllers/configureController.php
@@ -1,0 +1,9 @@
+<?php
+
+class FreshExtension_configure_Controller extends FreshRSS_configure_Controller {
+	public function readingAction(): void {
+	    Minz_Request::_param('lazyload', true); // Allowing to change this option is not a good idea here
+	    parent::readingAction();
+	}
+}
+

--- a/extension.php
+++ b/extension.php
@@ -38,6 +38,7 @@ class DemoExtension extends Minz_Extension {
         $this->registerController('extension');
         $this->registerController('user');
         $this->registerController('auth');
+        $this->registerController('configure');
         $this->registerViews();
     }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Demo",
   "author": "Marien Fressinaud",
   "description": "Extension for the demo version of FreshRSS",
-  "version": 0.2,
+  "version": 0.3,
   "entrypoint": "Demo",
   "type": "system"
 }


### PR DESCRIPTION
A combination of disabling lazyload + `<img src="./?c=auth&a=login&u=attacker&p=1234567">` in an added feed can allow for XSS* since a different user can use UserJS (and UserCSS)

*after signing into `demo` user